### PR TITLE
Make it work™

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ bld/
 [Oo]bj/
 [Ll]og/
 [Ll]ogs/
+lsp/
 
 # Visual Studio 2015/2017 cache/options directory
 .vs/
@@ -351,3 +352,4 @@ MigrationBackup/
 .idea/
 
 **/protos/*.cs
+**/Plugins/*/*.meta

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Visual Pinball Engine - MPF Gamelogic Engine
 *Enables the Mission Pinball Framework to drive VPE*
 
+[![UPM Package](https://img.shields.io/npm/v/org.visualpinball.engine.missionpinball?label=org.visualpinball.engine.missionpinball&registry_uri=https://registry.visualpinball.org&color=%2333cf57&logo=unity&style=flat)](https://registry.visualpinball.org/-/web/detail/org.visualpinball.engine.missionpinball)
+
 ## Structure
 
 This project contains three folders:

--- a/VisualPinball.Engine.Mpf.Test/NLog.config
+++ b/VisualPinball.Engine.Mpf.Test/NLog.config
@@ -1,0 +1,13 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+
+<nlog xmlns="http://www.nlog-project.org/schemas/NLog.xsd"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+
+    <targets>
+        <target name="logconsole" xsi:type="Console" />
+    </targets>
+
+    <rules>
+        <logger name="*" minlevel="Info" writeTo="logconsole" />
+    </rules>
+</nlog>

--- a/VisualPinball.Engine.Mpf.Test/Program.cs
+++ b/VisualPinball.Engine.Mpf.Test/Program.cs
@@ -12,6 +12,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Linq.Expressions;
 using System.Threading.Tasks;
 using VisualPinball.Engine.Mpf;
 
@@ -19,7 +20,7 @@ namespace MpfTest
 {
 	public static class Program
 	{
-		public static void Main(string[] args)
+		public static async Task Main(string[] args)
 		{
 			// Console.WriteLine("Starting...");
 			// var client = new MpfClient();
@@ -42,6 +43,21 @@ namespace MpfTest
 
 			var descr = mpfApi.GetMachineDescription();
 			Console.WriteLine($"Description: {descr} in {s.ElapsedMilliseconds}ms");
+
+			ConsoleKeyInfo key;
+			do {
+				key = Console.ReadKey();
+				switch (key.Key) {
+					case ConsoleKey.A:
+						await mpfApi.Switch("s_sling", true);
+						break;
+					case ConsoleKey.S:
+						await mpfApi.Switch("s_sling", false);
+						break;
+				}
+			} while (key.Key != ConsoleKey.Escape);
+
+			mpfApi.Dispose();
 		}
 	}
 }

--- a/VisualPinball.Engine.Mpf.Test/Program.cs
+++ b/VisualPinball.Engine.Mpf.Test/Program.cs
@@ -12,6 +12,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using VisualPinball.Engine.Mpf;
@@ -22,6 +23,8 @@ namespace MpfTest
 	{
 		public static async Task Main(string[] args)
 		{
+			var machineFolder = Path.GetFullPath(@"../../../../VisualPinball.Engine.Mpf/machine");
+
 			// Console.WriteLine("Starting...");
 			// var client = new MpfClient();
 			// client.Connect();
@@ -33,7 +36,7 @@ namespace MpfTest
 
 
 			var s = Stopwatch.StartNew();
-			var mpfApi = new MpfApi(@"../../../../VisualPinball.Engine.Mpf/machine");
+			var mpfApi = new MpfApi(machineFolder);
 
 			mpfApi.Launch();
 

--- a/VisualPinball.Engine.Mpf.Test/Program.cs
+++ b/VisualPinball.Engine.Mpf.Test/Program.cs
@@ -38,7 +38,7 @@ namespace MpfTest
 			var s = Stopwatch.StartNew();
 			var mpfApi = new MpfApi(machineFolder);
 
-			mpfApi.Launch();
+			mpfApi.Launch(new MpfConsoleOptions { ShowLogInsteadOfConsole = false });
 
 			mpfApi.StartGame(new Dictionary<string, bool> {
 				{"sw_11", false},
@@ -60,9 +60,6 @@ namespace MpfTest
 			};
 			mpfApi.Client.OnFadeLight += (_, request) => {
 				Console.WriteLine($"[MPF] light fades ({request.CommonFadeMs}ms):");
-				foreach (var fade in request.Fades.ToList()) {
-					Console.WriteLine($"  l{fade.LightNumber} @{fade.TargetBrightness}");
-				}
 			};
 
 			var descr = mpfApi.GetMachineDescription();
@@ -76,7 +73,7 @@ namespace MpfTest
 						await mpfApi.Switch("0", true);
 						break;
 					case ConsoleKey.S:
-						await mpfApi.Switch("1", false);
+						await mpfApi.Switch("0", false);
 						break;
 				}
 			} while (key.Key != ConsoleKey.Escape);

--- a/VisualPinball.Engine.Mpf.Test/Program.cs
+++ b/VisualPinball.Engine.Mpf.Test/Program.cs
@@ -12,7 +12,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq.Expressions;
+using System.Linq;
 using System.Threading.Tasks;
 using VisualPinball.Engine.Mpf;
 
@@ -40,6 +40,27 @@ namespace MpfTest
 			mpfApi.StartGame(new Dictionary<string, bool> {
 				{"sw_11", false},
 			});
+			mpfApi.Client.OnConfigureHardwareRule += (_, request) => {
+				Console.WriteLine($"[MPF] configure hw/rule: sw{request.SwitchNumber} -> c{request.CoilNumber} @{request.HoldPower} | pulse: {request.PulseMs}ms @{request.PulsePower}");
+			};
+			mpfApi.Client.OnRemoveHardwareRule += (_, request) => {
+				Console.WriteLine($"[MPF] remove hw/rule: sw{request.SwitchNumber} -> c{request.CoilNumber}");
+			};
+			mpfApi.Client.OnEnableCoil += (_, request) => {
+				Console.WriteLine($"[MPF] enable coil c{request.CoilNumber} @{request.HoldPower} | pulse: {request.PulseMs}ms @{request.PulsePower}");
+			};
+			mpfApi.Client.OnDisableCoil += (_, request) => {
+				Console.WriteLine($"[MPF] disable coil c{request.CoilNumber}");
+			};
+			mpfApi.Client.OnPulseCoil += (_, request) => {
+				Console.WriteLine($"[MPF] pulse coil c{request.CoilNumber} {request.PulseMs}ms @{request.PulsePower}");
+			};
+			mpfApi.Client.OnFadeLight += (_, request) => {
+				Console.WriteLine($"[MPF] light fades ({request.CommonFadeMs}ms):");
+				foreach (var fade in request.Fades.ToList()) {
+					Console.WriteLine($"  l{fade.LightNumber} @{fade.TargetBrightness}");
+				}
+			};
 
 			var descr = mpfApi.GetMachineDescription();
 			Console.WriteLine($"Description: {descr} in {s.ElapsedMilliseconds}ms");
@@ -49,10 +70,10 @@ namespace MpfTest
 				key = Console.ReadKey();
 				switch (key.Key) {
 					case ConsoleKey.A:
-						await mpfApi.Switch("s_sling", true);
+						await mpfApi.Switch("0", true);
 						break;
 					case ConsoleKey.S:
-						await mpfApi.Switch("s_sling", false);
+						await mpfApi.Switch("1", false);
 						break;
 				}
 			} while (key.Key != ConsoleKey.Escape);

--- a/VisualPinball.Engine.Mpf.Test/Program.cs
+++ b/VisualPinball.Engine.Mpf.Test/Program.cs
@@ -39,12 +39,17 @@ namespace MpfTest
 			var mpfApi = new MpfApi(machineFolder);
 
 			mpfApi.Launch(new MpfConsoleOptions {
-				ShowLogInsteadOfConsole = true,
-				CatchStdOut = true,
+				//ShowLogInsteadOfConsole = true,
+				//CatchStdOut = true,
 			});
 
 			mpfApi.StartGame(new Dictionary<string, bool> {
-				{"sw_11", false},
+				{"1", true},
+				{"2", true},
+				{"3", true},
+				{"4", true},
+				{"5", true},
+				{"6", true},
 			});
 			mpfApi.Client.OnConfigureHardwareRule += (_, request) => {
 				Console.WriteLine($"[MPF] configure hw/rule: sw{request.SwitchNumber} -> c{request.CoilNumber} @{request.HoldPower} | pulse: {request.PulseMs}ms @{request.PulsePower}");

--- a/VisualPinball.Engine.Mpf.Test/Program.cs
+++ b/VisualPinball.Engine.Mpf.Test/Program.cs
@@ -38,7 +38,10 @@ namespace MpfTest
 			var s = Stopwatch.StartNew();
 			var mpfApi = new MpfApi(machineFolder);
 
-			mpfApi.Launch(new MpfConsoleOptions { ShowLogInsteadOfConsole = false });
+			mpfApi.Launch(new MpfConsoleOptions {
+				ShowLogInsteadOfConsole = true,
+				CatchStdOut = true,
+			});
 
 			mpfApi.StartGame(new Dictionary<string, bool> {
 				{"sw_11", false},

--- a/VisualPinball.Engine.Mpf.Test/VisualPinball.Engine.Mpf.Test.csproj
+++ b/VisualPinball.Engine.Mpf.Test/VisualPinball.Engine.Mpf.Test.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>

--- a/VisualPinball.Engine.Mpf.Test/VisualPinball.Engine.Mpf.Test.csproj
+++ b/VisualPinball.Engine.Mpf.Test/VisualPinball.Engine.Mpf.Test.csproj
@@ -17,5 +17,11 @@
   <ItemGroup>
     <ProjectReference Include="..\VisualPinball.Engine.Mpf\VisualPinball.Engine.Mpf.csproj" />
   </ItemGroup>
+	
+  <ItemGroup>
+    <None Update="NLog.config">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
 
 </Project>

--- a/VisualPinball.Engine.Mpf.Unity/Editor/MpfGamelogicEngineInspector.cs
+++ b/VisualPinball.Engine.Mpf.Unity/Editor/MpfGamelogicEngineInspector.cs
@@ -70,6 +70,7 @@ namespace VisualPinball.Engine.Mpf.Unity.Editor
 			if (GUILayout.Button("Populate Hardware")) {
 				if (EditorUtility.DisplayDialog("Mission Pinball Framework", "This will clear all linked switches, coils and lamps and re-populate them. You sure you want to do that?", "Yes", "No")) {
 					_tableAuthoring.RepopulateHardware(_mpfEngine);
+					TableSelector.Instance.TableUpdated();
 					SceneView.RepaintAll();
 				}
 			}

--- a/VisualPinball.Engine.Mpf.Unity/Editor/MpfGamelogicEngineInspector.cs
+++ b/VisualPinball.Engine.Mpf.Unity/Editor/MpfGamelogicEngineInspector.cs
@@ -26,15 +26,27 @@ namespace VisualPinball.Engine.Mpf.Unity.Editor
 
 		public override void OnInspectorGUI()
 		{
-			if (GUILayout.Button("Connect")) {
-				_mpfEngine.Client.Connect();
+			var pos = EditorGUILayout.GetControlRect(true, 18f);
+			pos = EditorGUI.PrefixLabel(pos, new GUIContent("Machine Folder"));
+
+			if (GUI.Button(pos, _mpfEngine.MachineFolder, EditorStyles.objectField)) {
+				var path = EditorUtility.OpenFolderPanel("Mission Pinball Framework: Choose machine folder", _mpfEngine.MachineFolder, "");
+				if (!string.IsNullOrWhiteSpace(path)) {
+					_mpfEngine.MachineFolder = path;
+				}
 			}
-			if (GUILayout.Button("StartGame")) {
-				_mpfEngine.Client.Play();
+
+			if (GUILayout.Button("Synchronize")) {
+				_mpfEngine.GetMachineDescription();
 			}
-			if (GUILayout.Button("GetMachineDescription")) {
-				Debug.Log(_mpfEngine.Client.GetMachineDescription());
-			}
+
+
+			// if (GUILayout.Button("StartGame")) {
+			// 	_mpfEngine.Client.Play();
+			// }
+			// if (GUILayout.Button("GetMachineDescription")) {
+			// 	Debug.Log(_mpfEngine.Client.GetMachineDescription());
+			// }
 		}
 	}
 }

--- a/VisualPinball.Engine.Mpf.Unity/Editor/MpfGamelogicEngineInspector.cs
+++ b/VisualPinball.Engine.Mpf.Unity/Editor/MpfGamelogicEngineInspector.cs
@@ -9,6 +9,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
+using System.IO;
 using UnityEditor;
 using UnityEngine;
 
@@ -37,7 +38,18 @@ namespace VisualPinball.Engine.Mpf.Unity.Editor
 			}
 
 			if (GUILayout.Button("Synchronize")) {
-				_mpfEngine.GetMachineDescription();
+				if (!Directory.Exists(_mpfEngine.MachineFolder)) {
+					EditorUtility.DisplayDialog("Mission Pinball Framework", "Gotta choose a valid machine folder first!", "Okay");
+				} else if (!Directory.Exists(Path.Combine(_mpfEngine.MachineFolder, "config"))) {
+					EditorUtility.DisplayDialog("Mission Pinball Framework", $"{_mpfEngine.MachineFolder} doesn't seem a valid machine folder. We expect a \"config\" subfolder in there!", "Okay");
+				} else {
+					_mpfEngine.GetMachineDescription();
+				}
+			}
+
+			EditorGUILayout.LabelField("Switches", new GUIStyle(GUI.skin.label) { fontStyle = FontStyle.Bold });
+			foreach (var switchDescription in _mpfEngine.MachineDescription.Switches) {
+				EditorGUILayout.LabelField(switchDescription.HardwareNumber, switchDescription.Name);
 			}
 
 

--- a/VisualPinball.Engine.Mpf.Unity/Editor/MpfGamelogicEngineInspector.cs
+++ b/VisualPinball.Engine.Mpf.Unity/Editor/MpfGamelogicEngineInspector.cs
@@ -9,9 +9,12 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
+// ReSharper disable AssignmentInConditionalExpression
+
 using System.IO;
 using UnityEditor;
 using UnityEngine;
+using VisualPinball.Unity.Editor;
 
 namespace VisualPinball.Engine.Mpf.Unity.Editor
 {
@@ -19,6 +22,9 @@ namespace VisualPinball.Engine.Mpf.Unity.Editor
 	public class MpfGamelogicEngineInspector : UnityEditor.Editor
 	{
 		private MpfGamelogicEngine _mpfEngine;
+		private bool _foldoutSwitches;
+		private bool _foldoutCoils;
+		private bool _foldoutLamps;
 
 		private void OnEnable()
 		{
@@ -30,35 +36,59 @@ namespace VisualPinball.Engine.Mpf.Unity.Editor
 			var pos = EditorGUILayout.GetControlRect(true, 18f);
 			pos = EditorGUI.PrefixLabel(pos, new GUIContent("Machine Folder"));
 
-			if (GUI.Button(pos, _mpfEngine.MachineFolder, EditorStyles.objectField)) {
-				var path = EditorUtility.OpenFolderPanel("Mission Pinball Framework: Choose machine folder", _mpfEngine.MachineFolder, "");
+			if (GUI.Button(pos, _mpfEngine.machineFolder, EditorStyles.objectField)) {
+				var path = EditorUtility.OpenFolderPanel("Mission Pinball Framework: Choose machine folder", _mpfEngine.machineFolder, "");
 				if (!string.IsNullOrWhiteSpace(path)) {
-					_mpfEngine.MachineFolder = path;
+					_mpfEngine.machineFolder = path;
 				}
 			}
 
 			if (GUILayout.Button("Synchronize")) {
-				if (!Directory.Exists(_mpfEngine.MachineFolder)) {
+				if (!Directory.Exists(_mpfEngine.machineFolder)) {
 					EditorUtility.DisplayDialog("Mission Pinball Framework", "Gotta choose a valid machine folder first!", "Okay");
-				} else if (!Directory.Exists(Path.Combine(_mpfEngine.MachineFolder, "config"))) {
-					EditorUtility.DisplayDialog("Mission Pinball Framework", $"{_mpfEngine.MachineFolder} doesn't seem a valid machine folder. We expect a \"config\" subfolder in there!", "Okay");
+				} else if (!Directory.Exists(Path.Combine(_mpfEngine.machineFolder, "config"))) {
+					EditorUtility.DisplayDialog("Mission Pinball Framework", $"{_mpfEngine.machineFolder} doesn't seem a valid machine folder. We expect a \"config\" subfolder in there!", "Okay");
 				} else {
 					_mpfEngine.GetMachineDescription();
 				}
 			}
 
-			EditorGUILayout.LabelField("Switches", new GUIStyle(GUI.skin.label) { fontStyle = FontStyle.Bold });
-			foreach (var switchDescription in _mpfEngine.MachineDescription.Switches) {
-				EditorGUILayout.LabelField(switchDescription.HardwareNumber, switchDescription.Name);
+			var naStyle = new GUIStyle(GUI.skin.label) {
+				fontStyle = FontStyle.Italic
+			};
+
+			// list switches, coils and lamps
+			if (_mpfEngine.AvailableCoils.Length + _mpfEngine.AvailableSwitches.Length + _mpfEngine.AvailableLamps.Length > 0) {
+				if (_foldoutSwitches = EditorGUILayout.BeginFoldoutHeaderGroup(_foldoutSwitches, "Switches")) {
+					foreach (var sw in _mpfEngine.AvailableSwitches) {
+						EditorGUILayout.LabelField(new GUIContent($"  [{sw.InternalId}] {sw.Id} ", Icons.Switch(sw.NormallyClosed, IconSize.Small)));
+					}
+					if (_mpfEngine.AvailableSwitches.Length == 0) {
+						EditorGUILayout.LabelField("No switches in this machine.", naStyle);
+					}
+				}
+				EditorGUILayout.EndFoldoutHeaderGroup();
+
+				if (_foldoutCoils = EditorGUILayout.BeginFoldoutHeaderGroup(_foldoutCoils, "Coils")) {
+					foreach (var sw in _mpfEngine.AvailableCoils) {
+						EditorGUILayout.LabelField(new GUIContent($"  [{sw.InternalId}] {sw.Id} ", Icons.Coil(IconSize.Small)));
+					}
+					if (_mpfEngine.AvailableCoils.Length == 0) {
+						EditorGUILayout.LabelField("No coils in this machine.", naStyle);
+					}
+				}
+				EditorGUILayout.EndFoldoutHeaderGroup();
+
+				if (_foldoutLamps = EditorGUILayout.BeginFoldoutHeaderGroup(_foldoutLamps, "Lamps")) {
+					foreach (var sw in _mpfEngine.AvailableLamps) {
+						EditorGUILayout.LabelField(new GUIContent($"  [{sw.InternalId}] {sw.Id} ", Icons.Light(IconSize.Small)));
+					}
+					if (_mpfEngine.AvailableLamps.Length == 0) {
+						EditorGUILayout.LabelField("No lamps in this machine.", naStyle);
+					}
+				}
+				EditorGUILayout.EndFoldoutHeaderGroup();
 			}
-
-
-			// if (GUILayout.Button("StartGame")) {
-			// 	_mpfEngine.Client.Play();
-			// }
-			// if (GUILayout.Button("GetMachineDescription")) {
-			// 	Debug.Log(_mpfEngine.Client.GetMachineDescription());
-			// }
 		}
 	}
 }

--- a/VisualPinball.Engine.Mpf.Unity/Editor/VisualPinball.Engine.Mpf.Unity.Editor.asmdef
+++ b/VisualPinball.Engine.Mpf.Unity/Editor/VisualPinball.Engine.Mpf.Unity.Editor.asmdef
@@ -2,6 +2,7 @@
 	"name": "VisualPinball.Engine.Mpf.Unity.Editor",
 	"rootNamespace": "VisualPinball.Engine.Mpf.Unity.Editor",
 	"references": [
+		"VisualPinball.Engine",
 		"VisualPinball.Unity",
 		"VisualPinball.Unity.Editor",
 		"VisualPinball.Engine.Mpf.Unity"

--- a/VisualPinball.Engine.Mpf.Unity/Editor/VisualPinball.Engine.Mpf.Unity.Editor.asmdef
+++ b/VisualPinball.Engine.Mpf.Unity/Editor/VisualPinball.Engine.Mpf.Unity.Editor.asmdef
@@ -3,6 +3,7 @@
 	"rootNamespace": "VisualPinball.Engine.Mpf.Unity.Editor",
 	"references": [
 		"VisualPinball.Unity",
+		"VisualPinball.Unity.Editor",
 		"VisualPinball.Engine.Mpf.Unity"
 	],
 	"includePlatforms": [ "Editor" ],

--- a/VisualPinball.Engine.Mpf.Unity/README.md.meta
+++ b/VisualPinball.Engine.Mpf.Unity/README.md.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 40031c30860c49041a48ea2e1069f9af
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/VisualPinball.Engine.Mpf.Unity/Runtime/MpfExtensions.cs
+++ b/VisualPinball.Engine.Mpf.Unity/Runtime/MpfExtensions.cs
@@ -1,0 +1,39 @@
+﻿// Visual Pinball Engine
+// Copyright (C) 2021 freezy and VPE Team
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System.Collections.Generic;
+using System.Linq;
+using Mpf.Vpe;
+using VisualPinball.Engine.Game.Engines;
+
+namespace VisualPinball.Engine.Mpf.Unity
+{
+	public static class MpfExtensions
+	{
+		public static IEnumerable<GamelogicEngineSwitch> GetSwitches(this MachineDescription md)
+		{
+			return md.Switches.Select(sw => new GamelogicEngineSwitch(sw.Name, int.Parse(sw.HardwareNumber)) {
+				NormallyClosed = sw.SwitchType.ToLower() == "nc"
+			});
+		}
+
+		public static IEnumerable<GamelogicEngineCoil> GetCoils(this MachineDescription md)
+		{
+			return md.Coils.Select(coil => new GamelogicEngineCoil(coil.Name, int.Parse(coil.HardwareNumber)));
+		}
+
+		public static IEnumerable<GamelogicEngineLamp> GetLights(this MachineDescription md)
+		{
+			// todo color
+			return md.Lights.Select(light => new GamelogicEngineLamp(light.Name, int.Parse(light.HardwareChannelColor)));
+		}
+	}
+}

--- a/VisualPinball.Engine.Mpf.Unity/Runtime/MpfExtensions.cs
+++ b/VisualPinball.Engine.Mpf.Unity/Runtime/MpfExtensions.cs
@@ -11,7 +11,9 @@
 
 using System.Collections.Generic;
 using System.Linq;
+using System.Text.RegularExpressions;
 using Mpf.Vpe;
+using VisualPinball.Engine.Common;
 using VisualPinball.Engine.Game.Engines;
 
 namespace VisualPinball.Engine.Mpf.Unity
@@ -20,14 +22,92 @@ namespace VisualPinball.Engine.Mpf.Unity
 	{
 		public static IEnumerable<GamelogicEngineSwitch> GetSwitches(this MachineDescription md)
 		{
-			return md.Switches.Select(sw => new GamelogicEngineSwitch(sw.Name, int.Parse(sw.HardwareNumber)) {
-				NormallyClosed = sw.SwitchType.ToLower() == "nc"
+			return md.Switches.Select(sw => {
+				var gleSw = new GamelogicEngineSwitch(sw.Name, int.Parse(sw.HardwareNumber)) {
+					NormallyClosed = sw.SwitchType.ToLower() == "nc"
+				};
+
+				if (Regex.Match(sw.Name, "l(eft)?_?flipper|flipper_?l(eft)?", RegexOptions.IgnoreCase).Success) {
+					gleSw.Description = "Left Flipper Button";
+					gleSw.InputActionHint = InputConstants.ActionLeftFlipper;
+
+				} if (Regex.Match(sw.Name, "r(ight)?_?flipper|flipper_?r(ight)?", RegexOptions.IgnoreCase).Success) {
+					gleSw.Description = "Right Flipper Button";
+					gleSw.InputActionHint = InputConstants.ActionRightFlipper;
+
+				} else if (Regex.Match(sw.Name, "plunger", RegexOptions.IgnoreCase).Success) {
+					gleSw.Description = "Plunger Button";
+					gleSw.InputActionHint = InputConstants.ActionPlunger;
+
+				} else if (Regex.Match(sw.Name, "start", RegexOptions.IgnoreCase).Success) {
+					gleSw.Description = "Start Button";
+					gleSw.InputActionHint = InputConstants.ActionStartGame;
+
+				} else if (Regex.Match(sw.Name, "trough_?jam", RegexOptions.IgnoreCase).Success) {
+					gleSw.Description = "Trough: Jam Switch";
+					gleSw.DeviceHint = "^Trough\\s*\\d?";
+					gleSw.DeviceItemHint = "jam";
+
+				} else {
+					var troughSwitchMatch = Regex.Match(sw.Name, "trough_?(\\d+)", RegexOptions.IgnoreCase);
+					if (troughSwitchMatch.Success) {
+						var num = troughSwitchMatch.Groups[1].Value;
+						gleSw.Description = $"Trough {num}";
+						gleSw.DeviceHint = "^Trough\\s*\\d?";
+						gleSw.DeviceItemHint = num;
+					}
+				}
+
+				return gleSw;
 			});
 		}
 
 		public static IEnumerable<GamelogicEngineCoil> GetCoils(this MachineDescription md)
 		{
-			return md.Coils.Select(coil => new GamelogicEngineCoil(coil.Name, int.Parse(coil.HardwareNumber)));
+			var leftFlipperCoil = string.Empty;
+			var rightFlipperCoil = string.Empty;
+			var leftFlipperHoldCoil = string.Empty;
+			var rightFlipperHoldCoil = string.Empty;
+
+			var coils = md.Coils.Select(coil => {
+				var gleCoil = new GamelogicEngineCoil(coil.Name, int.Parse(coil.HardwareNumber));
+
+				if (Regex.Match(coil.Name, "(l(eft)?_?flipper|flipper_?l(eft)?_?(main)?)$", RegexOptions.IgnoreCase).Success) {
+					gleCoil.Description = "Left Flipper";
+					gleCoil.PlayfieldItemHint = "^(LeftFlipper|LFlipper|FlipperLeft|FlipperL)$";
+					leftFlipperCoil = coil.Name;
+
+				} else if (Regex.Match(coil.Name, "(l(eft)?_?flipper|flipper_?l(eft)?)_?hold$", RegexOptions.IgnoreCase).Success) {
+					gleCoil.Description = "Left Flipper (hold)";
+					leftFlipperHoldCoil = coil.Name;
+
+				} else if (Regex.Match(coil.Name, "(r(ight)?_?flipper|flipper_?r(ight)?_?(main)?)$", RegexOptions.IgnoreCase).Success) {
+					gleCoil.Description = "Right Flipper";
+					gleCoil.PlayfieldItemHint = "^(RightFlipper|RFlipper|FlipperRight|FlipperR)$";
+					rightFlipperCoil = coil.Name;
+
+				} else if (Regex.Match(coil.Name, "(r(ight)?_?flipper|flipper_?r(ight)?)_?hold$", RegexOptions.IgnoreCase).Success) {
+					gleCoil.Description = "Right Flipper (hold)";
+					rightFlipperHoldCoil = coil.Name;
+
+				} else if (Regex.Match(coil.Name, "trough_?eject", RegexOptions.IgnoreCase).Success) {
+					gleCoil.Description = "Trough Eject";
+					gleCoil.DeviceHint = "^Trough\\s*\\d?";
+					gleCoil.DeviceItemHint = "eject";
+				}
+
+				return gleCoil;
+			}).ToArray();
+
+			foreach (var coil in coils) {
+				if (coil.Id == leftFlipperHoldCoil) {
+					coil.MainCoilIdOfHoldCoil = leftFlipperCoil;
+				} else if (coil.Id == rightFlipperHoldCoil) {
+					coil.MainCoilIdOfHoldCoil = rightFlipperCoil;
+				}
+			}
+
+			return coils;
 		}
 
 		public static IEnumerable<GamelogicEngineLamp> GetLights(this MachineDescription md)

--- a/VisualPinball.Engine.Mpf.Unity/Runtime/MpfExtensions.cs.meta
+++ b/VisualPinball.Engine.Mpf.Unity/Runtime/MpfExtensions.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 7b7cf4dd31db4fc087b76e68f1c50c01
+timeCreated: 1615328604

--- a/VisualPinball.Engine.Mpf.Unity/Runtime/MpfGamelogicEngine.cs
+++ b/VisualPinball.Engine.Mpf.Unity/Runtime/MpfGamelogicEngine.cs
@@ -81,7 +81,16 @@ namespace VisualPinball.Engine.Mpf.Unity
 			_api.Client.OnRemoveHardwareRule += OnRemoveHardwareRule;
 			_api.Client.OnFadeLight += OnFadeLight;
 
-			_api.StartGame(player.SwitchStatusesClosed);
+			// map initial switches
+			var mappedSwitchStatuses = new Dictionary<string, bool>();
+			foreach (var swName in player.SwitchStatusesClosed.Keys) {
+				if (_switchIds.ContainsKey(swName)) {
+					mappedSwitchStatuses[_switchIds[swName].ToString()] = player.SwitchStatusesClosed[swName];
+				} else {
+					Logger.Warn($"Unknown intial switch name \"{swName}\".");
+				}
+			}
+			_api.StartGame(mappedSwitchStatuses);
 		}
 
 		public void Switch(string id, bool isClosed)

--- a/VisualPinball.Engine.Mpf.Unity/Runtime/MpfGamelogicEngine.cs
+++ b/VisualPinball.Engine.Mpf.Unity/Runtime/MpfGamelogicEngine.cs
@@ -26,5 +26,15 @@ namespace VisualPinball.Engine.Mpf.Unity
 		[NonSerialized]
 		public MpfClient Client = new MpfClient();
 
+		public string MachineFolder;
+
+		public void GetMachineDescription()
+		{
+			var client = new MpfClient();
+			client.Connect();
+			client.StartGame(new Dictionary<string, bool>());
+			Debug.Log("Description = " + client.GetMachineDescription());
+		}
+
 	}
 }

--- a/VisualPinball.Engine.Mpf.Unity/Runtime/MpfGamelogicEngine.cs
+++ b/VisualPinball.Engine.Mpf.Unity/Runtime/MpfGamelogicEngine.cs
@@ -68,7 +68,11 @@ namespace VisualPinball.Engine.Mpf.Unity
 				_coilNames[coil.InternalId.ToString()] = coil.Id;
 			}
 			_api = new MpfApi(machineFolder);
-			_api.Launch();
+			_api.Launch(new MpfConsoleOptions {
+				ShowLogInsteadOfConsole = false,
+				VerboseLogging = true,
+				UseMediaController = false,
+			});
 
 			_api.Client.OnEnableCoil += OnEnableCoil;
 			_api.Client.OnDisableCoil += OnDisableCoil;

--- a/VisualPinball.Engine.Mpf.Unity/Runtime/MpfGamelogicEngine.cs
+++ b/VisualPinball.Engine.Mpf.Unity/Runtime/MpfGamelogicEngine.cs
@@ -130,7 +130,12 @@ namespace VisualPinball.Engine.Mpf.Unity
 
 		private void OnPulseCoil(object sender, PulseCoilRequest e)
 		{
-			Logger.Info($"PULSING COIL {e.CoilNumber}");
+			if (_coilNames.ContainsKey(e.CoilNumber)) {
+				OnCoilChanged?.Invoke(this, new CoilEventArgs(_coilNames[e.CoilNumber], true));
+				_player.ScheduleAction((int)e.PulseMs, () => OnCoilChanged?.Invoke(this, new CoilEventArgs(_coilNames[e.CoilNumber], false)));
+			} else {
+				Logger.Error("Unmapped MPF coil " + e.CoilNumber);
+			}
 		}
 
 		private void OnFadeLight(object sender, FadeLightRequest e)

--- a/VisualPinball.Engine.Mpf.Unity/Runtime/MpfGamelogicEngine.cs
+++ b/VisualPinball.Engine.Mpf.Unity/Runtime/MpfGamelogicEngine.cs
@@ -10,8 +10,7 @@
 // SOFTWARE.
 
 using System;
-using System.Collections.Generic;
-using Mpf.Vpe;
+using System.Linq;
 using UnityEngine;
 using VisualPinball.Engine.Game.Engines;
 using VisualPinball.Unity;
@@ -22,19 +21,43 @@ namespace VisualPinball.Engine.Mpf.Unity
 	[ExecuteAlways]
 	[DisallowMultipleComponent]
 	[AddComponentMenu("Visual Pinball/Game Logic Engine/Mission Pinball Framework")]
-	public class MpfGamelogicEngine : MonoBehaviour
+	public class MpfGamelogicEngine : MonoBehaviour, IGamelogicEngine
 	{
+		public string Name { get; } = "Mission Pinball Framework";
+
+		public GamelogicEngineSwitch[] AvailableSwitches => availableSwitches;
+		public GamelogicEngineCoil[] AvailableCoils => availableCoils;
+		public GamelogicEngineLamp[] AvailableLamps => availableLamps;
+
+		public event EventHandler<LampEventArgs> OnLampChanged;
+		public event EventHandler<LampsEventArgs> OnLampsChanged;
+		public event EventHandler<LampColorEventArgs> OnLampColorChanged;
+
+		public event EventHandler<CoilEventArgs> OnCoilChanged;
+
 		[NonSerialized]
 		public MpfClient Client = new MpfClient();
 
-		public string MachineFolder;
+		public string machineFolder;
 
-		public MachineDescription MachineDescription;
+		[SerializeField] private GamelogicEngineSwitch[] availableSwitches = new GamelogicEngineSwitch[0];
+		[SerializeField] private GamelogicEngineCoil[] availableCoils = new GamelogicEngineCoil[0];
+		[SerializeField] private GamelogicEngineLamp[] availableLamps = new GamelogicEngineLamp[0];
+
+		public void OnInit(Player player, TableApi tableApi, BallManager ballManager)
+		{
+		}
+
+		public void Switch(string id, bool isClosed)
+		{
+		}
 
 		public void GetMachineDescription()
 		{
-			MachineDescription = MpfApi.GetMachineDescription(MachineFolder);
+			var md = MpfApi.GetMachineDescription(machineFolder);
+			availableSwitches = md.GetSwitches().ToArray();
+			availableCoils = md.GetCoils().ToArray();
+			availableLamps = md.GetLights().ToArray();
 		}
-
 	}
 }

--- a/VisualPinball.Engine.Mpf.Unity/Runtime/MpfGamelogicEngine.cs
+++ b/VisualPinball.Engine.Mpf.Unity/Runtime/MpfGamelogicEngine.cs
@@ -11,6 +11,7 @@
 
 using System;
 using System.Collections.Generic;
+using Mpf.Vpe;
 using UnityEngine;
 using VisualPinball.Engine.Game.Engines;
 using VisualPinball.Unity;
@@ -28,12 +29,11 @@ namespace VisualPinball.Engine.Mpf.Unity
 
 		public string MachineFolder;
 
+		public MachineDescription MachineDescription;
+
 		public void GetMachineDescription()
 		{
-			var client = new MpfClient();
-			client.Connect();
-			client.StartGame(new Dictionary<string, bool>());
-			Debug.Log("Description = " + client.GetMachineDescription());
+			MachineDescription = MpfApi.GetMachineDescription(MachineFolder);
 		}
 
 	}

--- a/VisualPinball.Engine.Mpf.Unity/package.json
+++ b/VisualPinball.Engine.Mpf.Unity/package.json
@@ -14,15 +14,7 @@
   },
   "author": "freezy <freezy@vpdb.io>",
   "contributors": [
-    "ravarcade <ravarcade@gmail.com>",
-    "shaderbytes",
-    "jsm174 <jsm174@gmail.com>",
-    "Roger Bocksnick <roger.bocksnick@gmail.com>",
-    "VrôÕnsh <vroonsh@free.fr>",
-    "Rowlan",
-    "Kleis Auke Wolthuizen <info@kleisauke.nl>",
-    "Eli Curtz <eli@nuprometheus.com>",
-    "Pandeli"
+    "jsm174 <jsm174@gmail.com>"
   ],
   "documentationUrl": "https://docs.visualpinball.org/",
   "changelogUrl": "https://docs.visualpinball.org/CHANGELOG.html",

--- a/VisualPinball.Engine.Mpf.Unity/package.json
+++ b/VisualPinball.Engine.Mpf.Unity/package.json
@@ -16,7 +16,7 @@
   "contributors": [
     "jsm174 <jsm174@gmail.com>"
   ],
-  "documentationUrl": "https://docs.visualpinball.org/",
+  "documentationUrl": "https://docs.visualpinball.org/plugins/mpf/",
   "changelogUrl": "https://docs.visualpinball.org/CHANGELOG.html",
   "licensesUrl": "https://github.com/VisualPinball/VisualPinball.Unity.Hdrp/blob/master/LICENSE",
   "repository": {

--- a/VisualPinball.Engine.Mpf/MpfApi.cs
+++ b/VisualPinball.Engine.Mpf/MpfApi.cs
@@ -31,7 +31,7 @@ namespace VisualPinball.Engine.Mpf
 		{
 			var client = new MpfClient();
 			var spawner = new MpfSpawner(machineFolder);
-			spawner.Spawn(new MpfConsoleOptions());
+			spawner.Spawn(new MpfConsoleOptions { ShowLogInsteadOfConsole = true });
 			client.Connect("localhost:50051");
 			client.StartGame(new Dictionary<string, bool>(), false);
 			var description = client.GetMachineDescription();

--- a/VisualPinball.Engine.Mpf/MpfApi.cs
+++ b/VisualPinball.Engine.Mpf/MpfApi.cs
@@ -19,7 +19,7 @@ namespace VisualPinball.Engine.Mpf
 {
 	public class MpfApi : IDisposable
 	{
-		private readonly MpfClient _client = new MpfClient();
+		public readonly MpfClient Client = new MpfClient();
 		private readonly MpfSpawner _spawner;
 
 		public MpfApi(string machineFolder)
@@ -35,7 +35,7 @@ namespace VisualPinball.Engine.Mpf
 		public void Launch(int port = 50051)
 		{
 			_spawner.Spawn();
-			_client.Connect($"localhost:{port}");
+			Client.Connect($"localhost:{port}");
 		}
 
 		/// <summary>
@@ -44,7 +44,7 @@ namespace VisualPinball.Engine.Mpf
 		/// <param name="initialSwitches">Initial switch states of the machine</param>
 		public void StartGame(Dictionary<string, bool> initialSwitches = null)
 		{
-			_client.StartGame(initialSwitches ?? new Dictionary<string, bool>());
+			Client.StartGame(initialSwitches ?? new Dictionary<string, bool>());
 		}
 
 		/// <summary>
@@ -52,17 +52,17 @@ namespace VisualPinball.Engine.Mpf
 		/// </summary>
 		public MachineDescription GetMachineDescription()
 		{
-			return _client.GetMachineDescription();
+			return Client.GetMachineDescription();
 		}
 
 		public async Task Switch(string swName, bool swValue)
 		{
-			await _client.Switch(swName, swValue);
+			await Client.Switch(swName, swValue);
 		}
 
 		public void Dispose()
 		{
-			_client?.Shutdown();
+			Client?.Shutdown();
 		}
 	}
 }

--- a/VisualPinball.Engine.Mpf/MpfApi.cs
+++ b/VisualPinball.Engine.Mpf/MpfApi.cs
@@ -27,6 +27,18 @@ namespace VisualPinball.Engine.Mpf
 			_spawner = new MpfSpawner(Path.GetFullPath(machineFolder));
 		}
 
+		public static MachineDescription GetMachineDescription(string machineFolder)
+		{
+			var client = new MpfClient();
+			var spawner = new MpfSpawner(machineFolder);
+			spawner.Spawn();
+			client.Connect("localhost:50051");
+			client.StartGame(new Dictionary<string, bool>(), false);
+			var description = client.GetMachineDescription();
+			client.Shutdown();
+			return description;
+		}
+
 		/// <summary>
 		/// Launches MPF in the background and connects to it via gRPC.
 		/// </summary>

--- a/VisualPinball.Engine.Mpf/MpfApi.cs
+++ b/VisualPinball.Engine.Mpf/MpfApi.cs
@@ -55,6 +55,11 @@ namespace VisualPinball.Engine.Mpf
 			return _client.GetMachineDescription();
 		}
 
+		public async Task Switch(string swName, bool swValue)
+		{
+			await _client.Switch(swName, swValue);
+		}
+
 		public void Dispose()
 		{
 			_client?.Shutdown();

--- a/VisualPinball.Engine.Mpf/MpfApi.cs
+++ b/VisualPinball.Engine.Mpf/MpfApi.cs
@@ -31,7 +31,7 @@ namespace VisualPinball.Engine.Mpf
 		{
 			var client = new MpfClient();
 			var spawner = new MpfSpawner(machineFolder);
-			spawner.Spawn();
+			spawner.Spawn(new MpfConsoleOptions());
 			client.Connect("localhost:50051");
 			client.StartGame(new Dictionary<string, bool>(), false);
 			var description = client.GetMachineDescription();
@@ -42,11 +42,12 @@ namespace VisualPinball.Engine.Mpf
 		/// <summary>
 		/// Launches MPF in the background and connects to it via gRPC.
 		/// </summary>
+		/// <param name="options">MPF options</param>
 		/// <param name="port">gRPC port to use for MPC/VPE communication</param>
 		/// <returns></returns>
-		public void Launch(int port = 50051)
+		public void Launch(MpfConsoleOptions options, int port = 50051)
 		{
-			_spawner.Spawn();
+			_spawner.Spawn(options);
 			Client.Connect($"localhost:{port}");
 		}
 

--- a/VisualPinball.Engine.Mpf/MpfClient.cs
+++ b/VisualPinball.Engine.Mpf/MpfClient.cs
@@ -53,7 +53,7 @@ namespace VisualPinball.Engine.Mpf
 				ms.InitialSwitchStates.Add(sw, initialSwitches[sw]);
 			}
 
-			Logger.Info("Starting client...");
+			Logger.Info("Starting player with machine state: " + ms);
 			_commandStream = _client.Start(ms);
 
 			if (handleStream) {

--- a/VisualPinball.Engine.Mpf/MpfClient.cs
+++ b/VisualPinball.Engine.Mpf/MpfClient.cs
@@ -101,7 +101,6 @@ namespace VisualPinball.Engine.Mpf
 					default:
 						throw new ArgumentOutOfRangeException();
 				}
-				Logger.Info($"{count} commands dispatched.");
 			}
 		}
 

--- a/VisualPinball.Engine.Mpf/MpfClient.cs
+++ b/VisualPinball.Engine.Mpf/MpfClient.cs
@@ -13,8 +13,9 @@ using Grpc.Core;
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
-using Google.Protobuf.Collections;
+using Grpc.Core.Utils;
 using Mpf.Vpe;
+using NLog;
 
 namespace VisualPinball.Engine.Mpf
 {
@@ -23,11 +24,22 @@ namespace VisualPinball.Engine.Mpf
 	/// </summary>
 	public class MpfClient
 	{
+		public event EventHandler<FadeLightRequest> OnFadeLight;
+		public event EventHandler<PulseCoilRequest> OnPulseCoil;
+		public event EventHandler<EnableCoilRequest> OnEnableCoil;
+		public event EventHandler<DisableCoilRequest> OnDisableCoil;
+		public event EventHandler<ConfigureHardwareRuleRequest> OnConfigureHardwareRule;
+		public event EventHandler<RemoveHardwareRuleRequest> OnRemoveHardwareRule;
+
 		private Channel _channel;
 		private MpfHardwareService.MpfHardwareServiceClient _client;
 
+		private static readonly Logger Logger = LogManager.GetCurrentClassLogger();
+
+
 		public void Connect(string serverIpPort = "127.0.0.1:50051")
 		{
+			Logger.Info($"Connecting to {serverIpPort}...");
 			_channel = new Channel(serverIpPort, ChannelCredentials.Insecure);
 			_client = new MpfHardwareService.MpfHardwareServiceClient(_channel);
 		}
@@ -38,11 +50,50 @@ namespace VisualPinball.Engine.Mpf
 			foreach (var sw in initialSwitches.Keys) {
 				ms.InitialSwitchStates.Add(sw, initialSwitches[sw]);
 			}
-			_client.Start(ms);
+
+			Logger.Info("Starting client...");
+			using (var call = _client.Start(ms)) {
+
+				Logger.Info("Client started, retrieving commands...");
+				var count = 0;
+				call.ResponseStream.ForEachAsync(commands => {
+
+					Logger.Info($"New command: {commands.CommandCase}");
+					count++;
+					switch (commands.CommandCase) {
+						case Commands.CommandOneofCase.None:
+							break;
+						case Commands.CommandOneofCase.FadeLight:
+							OnFadeLight?.Invoke(this, commands.FadeLight);
+							break;
+						case Commands.CommandOneofCase.PulseCoil:
+							OnPulseCoil?.Invoke(this, commands.PulseCoil);
+							break;
+						case Commands.CommandOneofCase.EnableCoil:
+							OnEnableCoil?.Invoke(this, commands.EnableCoil);
+							break;
+						case Commands.CommandOneofCase.DisableCoil:
+							OnDisableCoil?.Invoke(this, commands.DisableCoil);
+							break;
+						case Commands.CommandOneofCase.ConfigureHardwareRule:
+							OnConfigureHardwareRule?.Invoke(this, commands.ConfigureHardwareRule);
+							break;
+						case Commands.CommandOneofCase.RemoveHardwareRule:
+							OnRemoveHardwareRule?.Invoke(this, commands.RemoveHardwareRule);
+							break;
+						default:
+							throw new ArgumentOutOfRangeException();
+					}
+					return Task.CompletedTask;
+				}).Wait();
+
+				Logger.Info($"{count} commands dispatched.");
+			}
 		}
 
 		public MachineDescription GetMachineDescription()
 		{
+			Logger.Info($"Getting machine description...");
 			return _client.GetMachineDescription(new EmptyRequest());
 		}
 

--- a/VisualPinball.Engine.Mpf/MpfClient.cs
+++ b/VisualPinball.Engine.Mpf/MpfClient.cs
@@ -75,7 +75,6 @@ namespace VisualPinball.Engine.Mpf
 			Logger.Info("Client started, retrieving commands...");
 			while (await _commandStream.ResponseStream.MoveNext()) {
 				var commands = _commandStream.ResponseStream.Current;
-				Logger.Info($"New command: {commands.CommandCase}");
 				switch (commands.CommandCase) {
 					case Commands.CommandOneofCase.None:
 						break;

--- a/VisualPinball.Engine.Mpf/MpfSpawner.cs
+++ b/VisualPinball.Engine.Mpf/MpfSpawner.cs
@@ -64,14 +64,22 @@ namespace VisualPinball.Engine.Mpf
 				FileName = mpfExePath,
 				WorkingDirectory = _pwd,
 				Arguments = args,
-				UseShellExecute = true,
-				RedirectStandardOutput = false,
-
+				UseShellExecute = !options.CatchStdOut,
+				RedirectStandardOutput = options.CatchStdOut,
 			};
 
 			using (var process = Process.Start(info)) {
 				_ready.Release();
-				process.WaitForExit();
+				if (!options.CatchStdOut) {
+					process.WaitForExit();
+
+				} else {
+					using (var reader = process.StandardOutput) {
+						var result = reader.ReadToEnd();
+						Console.Write(result);
+						process.WaitForExit();
+					}
+				}
 			}
 		}
 
@@ -109,5 +117,6 @@ namespace VisualPinball.Engine.Mpf
 		public bool UseMediaController;
 		public bool ShowLogInsteadOfConsole;
 		public bool VerboseLogging = true;
+		public bool CatchStdOut;
 	}
 }

--- a/VisualPinball.Engine.Mpf/VisualPinball.Engine.Mpf.csproj
+++ b/VisualPinball.Engine.Mpf/VisualPinball.Engine.Mpf.csproj
@@ -7,14 +7,14 @@
     <AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
-    
+
   <PropertyGroup Condition="'$(RuntimeIdentifier)' == ''">
     <RuntimeIdentifier Condition="$([MSBuild]::IsOSPlatform('Windows')) And '$(PlatformTarget)' != 'x86'">win-x64</RuntimeIdentifier>
     <RuntimeIdentifier Condition="$([MSBuild]::IsOSPlatform('Windows')) And '$(PlatformTarget)' == 'x86'">win-x86</RuntimeIdentifier>
     <RuntimeIdentifier Condition="$([MSBuild]::IsOSPlatform('OSX'))">osx-x64</RuntimeIdentifier>
     <RuntimeIdentifier Condition="$([MSBuild]::IsOSPlatform('Linux'))">linux-x64</RuntimeIdentifier>
-  </PropertyGroup> 
-    
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="Grpc.Tools" Version="2.36.1">
       <PrivateAssets>all</PrivateAssets>
@@ -22,6 +22,7 @@
     </PackageReference>
     <PackageReference Include="Grpc" Version="2.36.1" />
     <PackageReference Include="Google.Protobuf" Version="3.15.5" />
+    <PackageReference Include="NLog" Version="4.7.7" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
@@ -30,11 +31,11 @@
   <ItemGroup>
     <Protobuf Include="protos/*.proto" OutputDir="$(ProjectDir)" GrpcServices="Client" />
   </ItemGroup>
-    
+
   <ItemGroup>
     <None Remove="tools/**" />
   </ItemGroup>
-    
+
   <ItemGroup>
     <InputAssemblies Include="$(OutDir)System.Buffers.dll" />
     <InputAssemblies Include="$(OutDir)System.Memory.dll" />
@@ -44,12 +45,12 @@
     <InputAssemblies Include="$(OutDir)Grpc.Core.Api.dll" />
     <InputAssemblies Include="$(OutDir)Grpc.Core.dll" />
   </ItemGroup>
-    
+
   <Target Name="ILRepack" AfterTargets="Build">
     <Exec Condition="$([MSBuild]::IsOSPlatform('Windows')) == 'true'" Command="tools\ILRepack.exe /target:library /internalize $(OutDir)$(AssemblyName).dll @(InputAssemblies, ' ') /out:$(OutDir)$(AssemblyName).dll" />
     <Exec Condition="$([MSBuild]::IsOSPlatform('Windows')) != 'true'" Command="mono tools/ILRepack.exe /target:library /internalize $(OutDir)$(AssemblyName).dll @(InputAssemblies, ' ') /out:$(OutDir)$(AssemblyName).dll" />
   </Target>
-    
+
   <Target Name="PluginsDeploy" AfterTargets="ILRepack">
     <Copy SourceFiles="$(OutDir)$(AssemblyName).dll" DestinationFolder="..\VisualPinball.Engine.Mpf.Unity\Plugins\$(RuntimeIdentifier)" SkipUnchangedFiles="true" />
     <Copy Condition="'$(RuntimeIdentifier)' == 'win-x64'" SourceFiles="$(OutDir)grpc_csharp_ext.x64.dll" DestinationFiles="..\VisualPinball.Engine.Mpf.Unity\Plugins\$(RuntimeIdentifier)\grpc_csharp_ext.dll" SkipUnchangedFiles="true" />
@@ -57,5 +58,5 @@
     <Copy Condition="'$(RuntimeIdentifier)' == 'osx-x64'" SourceFiles="$(OutDir)libgrpc_csharp_ext.x64.dylib" DestinationFiles="..\VisualPinball.Engine.Mpf.Unity\Plugins\$(RuntimeIdentifier)\libgrpc_csharp_ext.dylib" SkipUnchangedFiles="true" />
     <Copy Condition="'$(RuntimeIdentifier)' == 'linux-x64'" SourceFiles="$(OutDir)libgrpc_csharp_ext.x64.so" DestinationFiles="..\VisualPinball.Engine.Mpf.Unity\Plugins\$(RuntimeIdentifier)\libgrpc_csharp_ext.so" SkipUnchangedFiles="true" />
   </Target>
-  
+
 </Project>

--- a/VisualPinball.Engine.Mpf/machine/config/config.yaml
+++ b/VisualPinball.Engine.Mpf/machine/config/config.yaml
@@ -12,36 +12,82 @@ vpe:
   debug: True
 
 switches:
-  s_sling:
+  s_left_flipper:
     number: 0
-  s_flipper:
-    number: 3
-  s_test:
-    number: 6
+    tags: left_flipper
+  s_right_flipper:
+    number: 1
+    tags: right_flipper
 
 coils:
-  c_sling:
+  c_flipper_left_main:
     number: 0
-  c_flipper:
+  c_flipper_left_hold:
     number: 1
-    allow_enable: True
-  c_test:
+    allow_enable: true
+  c_flipper_right_main:
     number: 2
-    allow_enable: True
+  c_flipper_right_hold:
+    number: 3
+    allow_enable: true
 
-lights:
-  test_light1:
-    number: 0
-  test_light2:
-    number: 1
-
-autofire_coils:
-  ac_slingshot_test:
-    coil: c_sling
-    switch: s_sling
 
 flippers:
-  f_test:
-    main_coil: c_flipper
-    activation_switch: s_flipper
+  left_flipper:
+    main_coil: c_flipper_left_main
+    hold_coil: c_flipper_left_hold
+    activation_switch: s_left_flipper
+    enable_events: machine_reset_phase_3
+  right_flipper:
+    main_coil: c_flipper_right_main
+    hold_coil: c_flipper_right_hold
+    activation_switch: s_right_flipper
+    enable_events: machine_reset_phase_3
 
+
+
+#hardware:
+#  platform: visual_pinball_engine
+#
+#playfields:
+#  playfield:
+#    tags: default
+#    default_source_device: None
+#
+#vpe:
+#  debug: True
+#
+#switches:
+#  s_sling:
+#    number: 0
+#  s_flipper:
+#    number: 3
+#  s_test:
+#    number: 6
+#
+#coils:
+#  c_sling:
+#    number: 0
+#  c_flipper:
+#    number: 1
+#    allow_enable: True
+#  c_test:
+#    number: 2
+#    allow_enable: True
+#
+#lights:
+#  test_light1:
+#    number: 0
+#  test_light2:
+#    number: 1
+#
+#autofire_coils:
+#  ac_slingshot_test:
+#    coil: c_sling
+#    switch: s_sling
+#
+#flippers:
+#  f_test:
+#    main_coil: c_flipper
+#    activation_switch: s_flipper
+#

--- a/VisualPinball.Engine.Mpf/machine/config/config.yaml
+++ b/VisualPinball.Engine.Mpf/machine/config/config.yaml
@@ -28,7 +28,13 @@ switches:
   s_trough_jam:
     number: 7
   s_plunger:
-    number: 10
+    number: 21
+  s_start:
+    number: 22
+    tags: start
+  s_right_inlane:
+    number: 23
+    tags: playfield_active
 
 coils:
   c_flipper_left_main:
@@ -69,9 +75,7 @@ flippers:
     main_coil: c_flipper_left_main
     hold_coil: c_flipper_left_hold
     activation_switch: s_left_flipper
-    enable_events: machine_reset_phase_3
   right_flipper:
     main_coil: c_flipper_right_main
     hold_coil: c_flipper_right_hold
     activation_switch: s_right_flipper
-    enable_events: machine_reset_phase_3

--- a/VisualPinball.Engine.Mpf/machine/config/config.yaml
+++ b/VisualPinball.Engine.Mpf/machine/config/config.yaml
@@ -3,34 +3,66 @@
 hardware:
   platform: visual_pinball_engine
 
-playfields:
-  playfield:
-    tags: default
-    default_source_device: None
-
 vpe:
   debug: True
 
 switches:
   s_left_flipper:
-    number: 0
+    number: 11
     tags: left_flipper
   s_right_flipper:
-    number: 1
+    number: 12
     tags: right_flipper
+  s_trough1:
+    number: 1
+  s_trough2:
+    number: 2
+  s_trough3:
+    number: 3
+  s_trough4:
+    number: 4
+  s_trough5:
+    number: 5
+  s_trough6:
+    number: 6
+  s_trough_jam:
+    number: 7
+  s_plunger:
+    number: 10
 
 coils:
   c_flipper_left_main:
     number: 0
+    default_pulse_ms: 20
   c_flipper_left_hold:
     number: 1
+    default_pulse_ms: 20
     allow_enable: true
   c_flipper_right_main:
     number: 2
   c_flipper_right_hold:
     number: 3
     allow_enable: true
+  c_trough_eject:
+    number: 4
 
+ball_devices:
+  bd_trough:
+    ball_switches: s_trough1, s_trough2, s_trough3, s_trough4, s_trough5, s_trough6, s_trough_jam
+    eject_coil: c_trough_eject
+    tags: trough, home, drain
+    jam_switch: s_trough_jam
+    eject_coil_jam_pulse: 15ms
+    eject_targets: bd_plunger
+    debug: true
+  bd_plunger:
+    ball_switches: s_plunger
+    mechanical_eject: true
+
+playfields:
+  playfield:
+    tags: default
+    default_source_device: bd_plunger
 
 flippers:
   left_flipper:
@@ -43,51 +75,3 @@ flippers:
     hold_coil: c_flipper_right_hold
     activation_switch: s_right_flipper
     enable_events: machine_reset_phase_3
-
-
-
-#hardware:
-#  platform: visual_pinball_engine
-#
-#playfields:
-#  playfield:
-#    tags: default
-#    default_source_device: None
-#
-#vpe:
-#  debug: True
-#
-#switches:
-#  s_sling:
-#    number: 0
-#  s_flipper:
-#    number: 3
-#  s_test:
-#    number: 6
-#
-#coils:
-#  c_sling:
-#    number: 0
-#  c_flipper:
-#    number: 1
-#    allow_enable: True
-#  c_test:
-#    number: 2
-#    allow_enable: True
-#
-#lights:
-#  test_light1:
-#    number: 0
-#  test_light2:
-#    number: 1
-#
-#autofire_coils:
-#  ac_slingshot_test:
-#    coil: c_sling
-#    switch: s_sling
-#
-#flippers:
-#  f_test:
-#    main_coil: c_flipper
-#    activation_switch: s_flipper
-#


### PR DESCRIPTION
This PR adds the basic wiring to make the communication between MPF and VPE work. It needs the [feature/mpf](https://github.com/freezy/VisualPinball.Engine/tree/feature/mpf) branch of VPE to work (which contains the hardware rules implementation). MPF and VPE in action:

https://user-images.githubusercontent.com/70426/110865444-eb216500-82c3-11eb-8f2a-26eb7250b5ca.mp4

The test app now listens to keys. Use `S`/`A` to turn the left flipper switch on and off. `ESC` to exit.

In Unity, you can now pull the MPF machine description into the editor, and it shows the results in the inspector.

During gameplay, switches and coils are hooked, although coil pulses still need to be implemented.