### PR TITLE
ci: switch builds to use matrix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,9 +1,26 @@
 name: Build
-on: [push, pull_request]
+on: [ push, pull_request ]
+
+defaults:
+  run:
+    shell: bash
 
 jobs:
-  build-win-x64:
-    runs-on: windows-latest
+  build:
+    name: Build ${{ matrix.rid }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: windows-latest
+            rid: win-x64
+          - os: windows-latest
+            rid: win-x86
+          - os: macos-latest
+            rid: osx-x64
+          - os: ubuntu-latest
+            rid: linux-x64
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-dotnet@v1
@@ -12,83 +29,14 @@ jobs:
       - name: Build
         run: |
           cd VisualPinball.Engine.Mpf
-          dotnet build -c Release -r win-x64
+          dotnet build -c Release -r ${{ matrix.rid }}
 #     - name: Test
 #       run: |
 #         cd VisualPinball.Engine.Mpf.Test
-#         dotnet run -c Release -r win-x64
+#         dotnet run -c Release -r ${{ matrix.rid }}
       - run: |
           mkdir tmp
-          xcopy /E /I VisualPinball.Engine.Mpf.Unity\Plugins\win-x64 tmp\win-x64
-      - uses: actions/upload-artifact@v2
-        with:
-          name: Plugins
-          path: tmp
-
-  build-win-x86:
-    runs-on: windows-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-dotnet@v1
-        with:
-          dotnet-version: '3.1.x'
-      - name: Build
-        run: |
-          cd VisualPinball.Engine.Mpf
-          dotnet build -c Release -r win-x86
-#     - name: Test
-#       run: |
-#         cd VisualPinball.Engine.Mpf.Test
-#         dotnet run -c Release -r win-x86
-      - run: |
-          mkdir tmp
-          xcopy /E /I VisualPinball.Engine.Mpf.Unity\Plugins\win-x86 tmp\win-x86
-      - uses: actions/upload-artifact@v2
-        with:
-          name: Plugins
-          path: tmp
-
-  build-osx-x64:
-    runs-on: macos-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-dotnet@v1
-        with:
-          dotnet-version: '3.1.x'
-      - name: Build
-        run: |
-          cd VisualPinball.Engine.Mpf
-          dotnet build -c Release -r osx-x64
-#     - name: Test
-#       run: |
-#         cd VisualPinball.Engine.Mpf.Test
-#         dotnet run -c Release -r osx-x64
-      - run: |
-          mkdir tmp
-          cp -r VisualPinball.Engine.Mpf.Unity/Plugins/osx-x64 tmp
-      - uses: actions/upload-artifact@v2
-        with:
-          name: Plugins
-          path: tmp
-
-  build-linux-x64:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-dotnet@v1
-        with:
-          dotnet-version: '3.1.x'
-      - name: Build
-        run: |
-          cd VisualPinball.Engine.Mpf
-          dotnet build -c Release -r linux-x64
-#     - name: Test
-#       run: |
-#         cd VisualPinball.Engine.Mpf.Test
-#         dotnet run -c Release -r linux-x64
-      - run: |
-          mkdir tmp
-          cp -r VisualPinball.Engine.Mpf.Unity/Plugins/linux-x64 tmp
+          cp -r VisualPinball.Engine.Mpf.Unity/Plugins/${{ matrix.rid }} tmp
       - uses: actions/upload-artifact@v2
         with:
           name: Plugins
@@ -96,7 +44,7 @@ jobs:
 
   dispatch:
     runs-on: ubuntu-latest
-    needs: [ build-win-x64, build-win-x86, build-osx-x64, build-linux-x64 ]
+    needs: [ build ]
     if: github.repository == 'VisualPinball/VisualPinball.Engine.Mpf' && github.ref == 'refs/heads/master' && github.event_name == 'push'
     steps:
       - uses: peter-evans/repository-dispatch@v1


### PR DESCRIPTION
This PR uses a matrix for builds instead of 4 separate jobs.