### PR TITLE
Adapt API changes from internal id removal

### DIFF
--- a/VisualPinball.Engine.Mpf.Unity/Editor/MpfGamelogicEngineInspector.cs
+++ b/VisualPinball.Engine.Mpf.Unity/Editor/MpfGamelogicEngineInspector.cs
@@ -85,7 +85,7 @@ namespace VisualPinball.Engine.Mpf.Unity.Editor
 			if (_mpfEngine.RequestedCoils.Length + _mpfEngine.RequestedSwitches.Length + _mpfEngine.RequestedLamps.Length > 0) {
 				if (_foldoutSwitches = EditorGUILayout.BeginFoldoutHeaderGroup(_foldoutSwitches, "Switches")) {
 					foreach (var sw in _mpfEngine.RequestedSwitches) {
-						EditorGUILayout.LabelField(new GUIContent($"  [{sw.InternalId}] {sw.Id} ", Icons.Switch(sw.NormallyClosed, IconSize.Small)));
+						EditorGUILayout.LabelField(new GUIContent($"  {sw.Id} ", Icons.Switch(sw.NormallyClosed, IconSize.Small)));
 					}
 					if (_mpfEngine.RequestedSwitches.Length == 0) {
 						EditorGUILayout.LabelField("No switches in this machine.", naStyle);
@@ -95,7 +95,7 @@ namespace VisualPinball.Engine.Mpf.Unity.Editor
 
 				if (_foldoutCoils = EditorGUILayout.BeginFoldoutHeaderGroup(_foldoutCoils, "Coils")) {
 					foreach (var sw in _mpfEngine.RequestedCoils) {
-						EditorGUILayout.LabelField(new GUIContent($"  [{sw.InternalId}] {sw.Id} ", Icons.Coil(IconSize.Small)));
+						EditorGUILayout.LabelField(new GUIContent($"  {sw.Id} ", Icons.Coil(IconSize.Small)));
 					}
 					if (_mpfEngine.RequestedCoils.Length == 0) {
 						EditorGUILayout.LabelField("No coils in this machine.", naStyle);
@@ -105,7 +105,7 @@ namespace VisualPinball.Engine.Mpf.Unity.Editor
 
 				if (_foldoutLamps = EditorGUILayout.BeginFoldoutHeaderGroup(_foldoutLamps, "Lamps")) {
 					foreach (var sw in _mpfEngine.RequestedLamps) {
-						EditorGUILayout.LabelField(new GUIContent($"  [{sw.InternalId}] {sw.Id} ", Icons.Light(IconSize.Small)));
+						EditorGUILayout.LabelField(new GUIContent($"  {sw.Id} ", Icons.Light(IconSize.Small)));
 					}
 					if (_mpfEngine.RequestedLamps.Length == 0) {
 						EditorGUILayout.LabelField("No lamps in this machine.", naStyle);

--- a/VisualPinball.Engine.Mpf.Unity/Runtime/MpfExtensions.cs
+++ b/VisualPinball.Engine.Mpf.Unity/Runtime/MpfExtensions.cs
@@ -24,7 +24,7 @@ namespace VisualPinball.Engine.Mpf.Unity
 		public static IEnumerable<GamelogicEngineSwitch> GetSwitches(this MachineDescription md)
 		{
 			return md.Switches.Select(sw => {
-				var gleSw = new GamelogicEngineSwitch(sw.Name, int.Parse(sw.HardwareNumber)) {
+				var gleSw = new GamelogicEngineSwitch(sw.Name) {
 					NormallyClosed = sw.SwitchType.ToLower() == "nc"
 				};
 
@@ -66,7 +66,7 @@ namespace VisualPinball.Engine.Mpf.Unity
 		public static IEnumerable<GamelogicEngineCoil> GetCoils(this MachineDescription md)
 		{
 			var coils = md.Coils.Select(coil => {
-				var gleCoil = new GamelogicEngineCoil(coil.Name, int.Parse(coil.HardwareNumber));
+				var gleCoil = new GamelogicEngineCoil(coil.Name);
 
 				if (Regex.Match(coil.Name, "(l(eft)?_?flipper|flipper_?l(eft)?_?(main)?)$", RegexOptions.IgnoreCase).Success) {
 					gleCoil.Description = "Left Flipper";
@@ -103,7 +103,7 @@ namespace VisualPinball.Engine.Mpf.Unity
 		public static IEnumerable<GamelogicEngineLamp> GetLights(this MachineDescription md)
 		{
 			// todo color
-			return md.Lights.Select(light => new GamelogicEngineLamp(light.Name, int.Parse(light.HardwareChannelColor)));
+			return md.Lights.Select(light => new GamelogicEngineLamp(light.Name));
 		}
 	}
 }

--- a/VisualPinball.Engine.Mpf.Unity/Runtime/MpfGamelogicEngine.cs
+++ b/VisualPinball.Engine.Mpf.Unity/Runtime/MpfGamelogicEngine.cs
@@ -69,16 +69,15 @@ namespace VisualPinball.Engine.Mpf.Unity
 			_player = player;
 			_switchIds.Clear();
 			foreach (var sw in requiredSwitches) {
-				_switchIds[sw.Id] = sw.InternalId;
-				_switchNames[sw.InternalId.ToString()] = sw.Id;
+				_switchNames[sw.Id] = sw.Id;
 			}
 			_coilNames.Clear();
 			foreach (var coil in requiredCoils) {
-				_coilNames[coil.InternalId.ToString()] = coil.Id;
+				_coilNames[coil.Id] = coil.Id;
 			}
 			_lampNames.Clear();
 			foreach (var lamp in requiredLamps) {
-				_lampNames[lamp.InternalId.ToString()] = lamp.Id;
+				_lampNames[lamp.Id] = lamp.Id;
 			}
 			_api = new MpfApi(machineFolder);
 			_api.Launch(new MpfConsoleOptions {

--- a/VisualPinball.Engine.Mpf.Unity/package.json
+++ b/VisualPinball.Engine.Mpf.Unity/package.json
@@ -7,10 +7,10 @@
     "Unity",
     "Mission Pinball Framework"
   ],
-  "unity": "2021.2",
-  "unityRelease": "7f1",
+  "unity": "2021.3",
+  "unityRelease": "0f1",
   "dependencies": {
-    "org.visualpinball.engine.unity": "0.0.1-preview.84"
+    "org.visualpinball.engine.unity": "0.0.1-preview.105"
   },
   "author": "freezy <freezy@vpdb.io>",
   "contributors": [

--- a/VisualPinball.Engine.Mpf/VisualPinball.Engine.Mpf.csproj
+++ b/VisualPinball.Engine.Mpf/VisualPinball.Engine.Mpf.csproj
@@ -16,13 +16,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Grpc.Tools" Version="2.42.0">
+    <PackageReference Include="Grpc.Tools" Version="2.46.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Grpc" Version="2.42.0" />
-    <PackageReference Include="Google.Protobuf" Version="3.19.1" />
-    <PackageReference Include="NLog" Version="4.7.12" />
+    <PackageReference Include="Grpc" Version="2.46.3" />
+    <PackageReference Include="Google.Protobuf" Version="3.20.1" />
+    <PackageReference Include="NLog" Version="4.7.15" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This PR removes the usage of internal id with the v0.0.1-preview.105 VPE release.

See https://github.com/freezy/VisualPinball.Engine/pull/408 and https://github.com/VisualPinball/VisualPinball.Engine.PinMAME/pull/26

Closes #12.