### PR TITLE
misc: update to latest gle interface

### DIFF
--- a/VisualPinball.Engine.Mpf.Unity/Runtime/MpfGamelogicEngine.cs
+++ b/VisualPinball.Engine.Mpf.Unity/Runtime/MpfGamelogicEngine.cs
@@ -39,7 +39,8 @@ namespace VisualPinball.Engine.Mpf.Unity
 		public event EventHandler<LampsEventArgs> OnLampsChanged;
 		public event EventHandler<CoilEventArgs> OnCoilChanged;
 		public event EventHandler<RequestedDisplays> OnDisplaysRequested;
-		public event EventHandler<DisplayFrameData> OnDisplayFrame;
+		public event EventHandler<string> OnDisplayClear;
+		public event EventHandler<DisplayFrameData> OnDisplayUpdateFrame;
 		public event EventHandler<SwitchEventArgs2> OnSwitchChanged;
 
 		[NonSerialized]
@@ -274,9 +275,13 @@ namespace VisualPinball.Engine.Mpf.Unity
 
 			lock (_dispatchQueue) {
 
-				_dispatchQueue.Enqueue(() => OnDisplayFrame?.Invoke(this,
+				_dispatchQueue.Enqueue(() => OnDisplayUpdateFrame?.Invoke(this,
 					new DisplayFrameData(frame.Name, DisplayFrameFormat.Dmd24, frame.FrameData())));
 			}
+		}
+
+		public void DisplayChanged(DisplayFrameData displayFrameData)
+		{
 		}
 
 		private void OnDestroy()

--- a/VisualPinball.Engine.Mpf.Unity/package.json
+++ b/VisualPinball.Engine.Mpf.Unity/package.json
@@ -10,7 +10,7 @@
   "unity": "2021.3",
   "unityRelease": "0f1",
   "dependencies": {
-    "org.visualpinball.engine.unity": "0.0.1-preview.105"
+    "org.visualpinball.engine.unity": "0.0.1-preview.119"
   },
   "author": "freezy <freezy@vpdb.io>",
   "contributors": [


### PR DESCRIPTION
This PR updates `MpfGamelogicEngine` to use the latest updates to `IGamelogicEngine`.

Before merging, and after VPE is merged, we should update `package.json` accordingly:

```
  "dependencies": {
    "org.visualpinball.engine.unity": "0.0.1-preview.xxx"
  },
```