### PR TITLE
Properly serialize machine description

### DIFF
--- a/VisualPinball.Engine.Mpf.Unity/Runtime/MpfExtensions.cs
+++ b/VisualPinball.Engine.Mpf.Unity/Runtime/MpfExtensions.cs
@@ -21,10 +21,10 @@ namespace VisualPinball.Engine.Mpf.Unity
 {
 	public static class MpfExtensions
 	{
-		public static IEnumerable<GamelogicEngineSwitch> GetSwitches(this MachineDescription md)
+		public static IEnumerable<SerializedGamelogicEngineSwitch> GetSwitches(this MachineDescription md)
 		{
 			return md.Switches.Select(sw => {
-				var gleSw = new GamelogicEngineSwitch(sw.Name) {
+				var gleSw = new SerializedGamelogicEngineSwitch(sw.Name) {
 					NormallyClosed = sw.SwitchType.ToLower() == "nc"
 				};
 
@@ -63,10 +63,10 @@ namespace VisualPinball.Engine.Mpf.Unity
 			});
 		}
 
-		public static IEnumerable<GamelogicEngineCoil> GetCoils(this MachineDescription md)
+		public static IEnumerable<SerializedGamelogicEngineCoil> GetCoils(this MachineDescription md)
 		{
 			var coils = md.Coils.Select(coil => {
-				var gleCoil = new GamelogicEngineCoil(coil.Name);
+				var gleCoil = new SerializedGamelogicEngineCoil(coil.Name);
 
 				if (Regex.Match(coil.Name, "(l(eft)?_?flipper|flipper_?l(eft)?_?(main)?)$", RegexOptions.IgnoreCase).Success) {
 					gleCoil.Description = "Left Flipper";
@@ -100,10 +100,10 @@ namespace VisualPinball.Engine.Mpf.Unity
 			return coils;
 		}
 
-		public static IEnumerable<GamelogicEngineLamp> GetLights(this MachineDescription md)
+		public static IEnumerable<SerializedGamelogicEngineLamp> GetLights(this MachineDescription md)
 		{
 			// todo color
-			return md.Lights.Select(light => new GamelogicEngineLamp(light.Name));
+			return md.Lights.Select(light => new SerializedGamelogicEngineLamp(light.Name));
 		}
 	}
 }

--- a/VisualPinball.Engine.Mpf.Unity/Runtime/MpfGamelogicEngine.cs
+++ b/VisualPinball.Engine.Mpf.Unity/Runtime/MpfGamelogicEngine.cs
@@ -15,6 +15,7 @@ using System.Linq;
 using Mpf.Vpe;
 using NLog;
 using UnityEngine;
+using UnityEditor;
 using VisualPinball.Engine.Game.Engines;
 using VisualPinball.Unity;
 using Logger = NLog.Logger;
@@ -144,6 +145,8 @@ namespace VisualPinball.Engine.Mpf.Unity
 			}
 
 			if (md != null) {
+				Undo.RecordObject(this, "Get machine description");
+				PrefabUtility.RecordPrefabInstancePropertyModifications(this);
 				requiredSwitches = md.GetSwitches().ToArray();
 				requiredCoils = md.GetCoils().ToArray();
 				requiredLamps = md.GetLights().ToArray();

--- a/VisualPinball.Engine.Mpf.Unity/Runtime/MpfGamelogicEngine.cs
+++ b/VisualPinball.Engine.Mpf.Unity/Runtime/MpfGamelogicEngine.cs
@@ -49,9 +49,9 @@ namespace VisualPinball.Engine.Mpf.Unity
 
 		public string machineFolder;
 
-		[SerializeField] private GamelogicEngineSwitch[] requiredSwitches = Array.Empty<GamelogicEngineSwitch>();
-		[SerializeField] private GamelogicEngineCoil[] requiredCoils = Array.Empty<GamelogicEngineCoil>();
-		[SerializeField] private GamelogicEngineLamp[] requiredLamps = Array.Empty<GamelogicEngineLamp>();
+		[SerializeField] private SerializedGamelogicEngineSwitch[] requiredSwitches = Array.Empty<SerializedGamelogicEngineSwitch>();
+		[SerializeField] private SerializedGamelogicEngineCoil[] requiredCoils = Array.Empty<SerializedGamelogicEngineCoil>();
+		[SerializeField] private SerializedGamelogicEngineLamp[] requiredLamps = Array.Empty<SerializedGamelogicEngineLamp>();
 		[SerializeField] private GamelogicEngineWire[] availableWires = Array.Empty<GamelogicEngineWire>();
 
 		private Player _player;

--- a/VisualPinball.Engine.Mpf.Unity/Runtime/MpfGamelogicEngine.cs
+++ b/VisualPinball.Engine.Mpf.Unity/Runtime/MpfGamelogicEngine.cs
@@ -15,7 +15,9 @@ using System.Linq;
 using Mpf.Vpe;
 using NLog;
 using UnityEngine;
+#if UNITY_EDITOR
 using UnityEditor;
+#endif
 using VisualPinball.Engine.Game.Engines;
 using VisualPinball.Unity;
 using Logger = NLog.Logger;
@@ -145,8 +147,10 @@ namespace VisualPinball.Engine.Mpf.Unity
 			}
 
 			if (md != null) {
+#if UNITY_EDITOR
 				Undo.RecordObject(this, "Get machine description");
 				PrefabUtility.RecordPrefabInstancePropertyModifications(this);
+#endif
 				requiredSwitches = md.GetSwitches().ToArray();
 				requiredCoils = md.GetCoils().ToArray();
 				requiredLamps = md.GetLights().ToArray();


### PR DESCRIPTION
Register changes to machine description with Unity Editor systems to ensure they are saved with the scene. Partially resolves issue #19.