### PR TITLE
Portable machine folder

### DIFF
--- a/VisualPinball.Engine.Mpf.Unity/Editor/MpfGamelogicEngineInspector.cs
+++ b/VisualPinball.Engine.Mpf.Unity/Editor/MpfGamelogicEngineInspector.cs
@@ -46,21 +46,29 @@ namespace VisualPinball.Engine.Mpf.Unity.Editor
 				return;
 			}
 
-			var pos = EditorGUILayout.GetControlRect(true, 18f);
+            if (!string.IsNullOrEmpty(_mpfEngine.MachineFolder) && !_mpfEngine.MachineFolder.Contains("StreamingAssets")) {
+                EditorGUILayout.HelpBox("The machine folder is not in the 'StreamingAssets' folder. It will not be included in builds.", MessageType.Warning);
+            }
+
+            var pos = EditorGUILayout.GetControlRect(true, 18f);
 			pos = EditorGUI.PrefixLabel(pos, new GUIContent("Machine Folder"));
 
-			if (GUI.Button(pos, _mpfEngine.machineFolder, EditorStyles.objectField)) {
-				var path = EditorUtility.OpenFolderPanel("Mission Pinball Framework: Choose machine folder", _mpfEngine.machineFolder, "");
+			if (GUI.Button(pos, _mpfEngine.MachineFolder, EditorStyles.objectField)) {
+				if (!Directory.Exists(Application.streamingAssetsPath)) {
+					Directory.CreateDirectory(Application.streamingAssetsPath);
+				}
+				var openFolder = Directory.Exists(_mpfEngine.MachineFolder) ? _mpfEngine.MachineFolder : Application.streamingAssetsPath;
+				var path = EditorUtility.OpenFolderPanel("Mission Pinball Framework: Choose machine folder", openFolder, "");
 				if (!string.IsNullOrWhiteSpace(path)) {
-					_mpfEngine.machineFolder = path;
+					_mpfEngine.MachineFolder = path;
 				}
 			}
 
 			if (GUILayout.Button("Get Machine Description")) {
-				if (!Directory.Exists(_mpfEngine.machineFolder)) {
+				if (!Directory.Exists(_mpfEngine.MachineFolder)) {
 					EditorUtility.DisplayDialog("Mission Pinball Framework", "Gotta choose a valid machine folder first!", "Okay");
-				} else if (!Directory.Exists(Path.Combine(_mpfEngine.machineFolder, "config"))) {
-					EditorUtility.DisplayDialog("Mission Pinball Framework", $"{_mpfEngine.machineFolder} doesn't seem a valid machine folder. We expect a \"config\" subfolder in there!", "Okay");
+				} else if (!Directory.Exists(Path.Combine(_mpfEngine.MachineFolder, "config"))) {
+					EditorUtility.DisplayDialog("Mission Pinball Framework", $"{_mpfEngine.MachineFolder} doesn't seem a valid machine folder. We expect a \"config\" subfolder in there!", "Okay");
 				} else {
 					_mpfEngine.GetMachineDescription();
 				}

--- a/VisualPinball.Engine.Mpf.Unity/Runtime/MpfGamelogicEngine.cs
+++ b/VisualPinball.Engine.Mpf.Unity/Runtime/MpfGamelogicEngine.cs
@@ -59,7 +59,11 @@ namespace VisualPinball.Engine.Mpf.Unity
 			}
 			set
 			{
-				if (value.Contains("StreamingAssets/"))
+#if UNITY_EDITOR
+                Undo.RecordObject(this, "Set machine folder");
+                PrefabUtility.RecordPrefabInstancePropertyModifications(this);
+#endif
+                if (value.Contains("StreamingAssets/"))
 				{
 					_machineFolder = "./StreamingAssets/" + value.Split("StreamingAssets/")[1];
 				}

--- a/VisualPinball.Engine.Mpf.Unity/Runtime/MpfGamelogicEngine.cs
+++ b/VisualPinball.Engine.Mpf.Unity/Runtime/MpfGamelogicEngine.cs
@@ -18,6 +18,7 @@ using UnityEngine;
 using VisualPinball.Engine.Game.Engines;
 using VisualPinball.Unity;
 using Logger = NLog.Logger;
+using System.IO;
 
 namespace VisualPinball.Engine.Mpf.Unity
 {
@@ -46,7 +47,29 @@ namespace VisualPinball.Engine.Mpf.Unity
 		[NonSerialized]
 		private MpfApi _api;
 
-		public string machineFolder;
+		public string MachineFolder
+		{
+			get
+			{
+				if (_machineFolder != null && _machineFolder.Contains("StreamingAssets/"))
+				{
+					return Path.Combine(Application.streamingAssetsPath, _machineFolder.Split("StreamingAssets/")[1]);
+				}
+				return _machineFolder;
+			}
+			set
+			{
+				if (value.Contains("StreamingAssets/"))
+				{
+					_machineFolder = "./StreamingAssets/" + value.Split("StreamingAssets/")[1];
+				}
+				else
+				{
+					_machineFolder = value;
+				}
+			}
+		}
+		[SerializeField] private string _machineFolder;
 
 		[SerializeField] private GamelogicEngineSwitch[] requiredSwitches = Array.Empty<GamelogicEngineSwitch>();
 		[SerializeField] private GamelogicEngineCoil[] requiredCoils = Array.Empty<GamelogicEngineCoil>();
@@ -80,7 +103,7 @@ namespace VisualPinball.Engine.Mpf.Unity
 			foreach (var lamp in requiredLamps) {
 				_lampNames[lamp.Id] = lamp.Id;
 			}
-			_api = new MpfApi(machineFolder);
+			_api = new MpfApi(MachineFolder);
 			_api.Launch(new MpfConsoleOptions {
 				ShowLogInsteadOfConsole = false,
 				VerboseLogging = true,
@@ -136,7 +159,7 @@ namespace VisualPinball.Engine.Mpf.Unity
 			MachineDescription md = null;
 
 			try {
-				md = MpfApi.GetMachineDescription(machineFolder);
+				md = MpfApi.GetMachineDescription(MachineFolder);
 			}
 
 			catch (Exception e) {


### PR DESCRIPTION
The machine folder is currently always saved as an absolute path. If the Unity project or a build is opened on a different computer, MPF will stop working. Unity has a special [`StreamingAssets` folder](https://docs.unity3d.com/Manual/StreamingAssets.html) that allows files to be included in the build process without being converted to binary. I think this is a good place for the MPF machine folder, because it allows a user to keep everything related to a table inside the Unity project and in one repository. I have turned the `MpfGamelogicEngine.machineFolder` field into a property with some parsing logic to recognize when the machine folder is inside the `StreamingAssets` folder. The folder is then serialized as a relative path and reconstructed to an absolute path whenever the property getter is called. This makes it portable between different computers. Additionally, I have changed the custom inspector of `MpfGamelogicEngine` to show the project's `StreamingAssets` folder when selecting a machine folder if there is no path set already. The user can still select a machine folder outside of `StreamingAssets`, but a warning will be displayed in that case.