### PR TITLE
Patch test program for MPF v0.80

### DIFF
--- a/VisualPinball.Engine.Mpf.Test/Program.cs
+++ b/VisualPinball.Engine.Mpf.Test/Program.cs
@@ -38,8 +38,7 @@ namespace MpfTest
 			var mpfApi = new MpfApi(machineFolder);
 
 			mpfApi.Launch(new MpfConsoleOptions {
-				//ShowLogInsteadOfConsole = true,
-				//CatchStdOut = true,
+				MediaController = MediaController.None
 			});
 
 			mpfApi.StartGame(new Dictionary<string, bool> {
@@ -87,10 +86,10 @@ namespace MpfTest
 				key = Console.ReadKey();
 				switch (key.Key) {
 					case ConsoleKey.A:
-						await mpfApi.Switch("0", true);
+						await mpfApi.Switch("22", true);
 						break;
 					case ConsoleKey.S:
-						await mpfApi.Switch("0", false);
+						await mpfApi.Switch("22", false);
 						break;
 				}
 			} while (key.Key != ConsoleKey.Escape);

--- a/VisualPinball.Engine.Mpf/machine/config/config.yaml
+++ b/VisualPinball.Engine.Mpf/machine/config/config.yaml
@@ -1,4 +1,4 @@
-#config_version=5
+#config_version=6
 
 displays:
   dmd:  # source display for the DMD


### PR DESCRIPTION
- Updates config version to 6
- Fixes test switch id from 0 to 22 (No switch in config has id 0)
- Passes `MediaController.None` to MPF so it won't look for the new Godot media controller